### PR TITLE
Nuevo metodo para conectarse a WiFi

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,29 @@ El presente documento no pretende ser una guía completa para la instalación de
 
         ping archlinux.org
 
-7. En caso de tener sólo wifi, usar:
+7. En caso de tener sólo wifi, usar [iwctl](https://wiki.archlinux.org/index.php/Iwd#iwctl):
 
-        wifi-menu
+        iwctl
+    
+    Listar los dispositivos:
+    
+        device list
+        
+    Escanear redes:
+    
+        station <dispositivo> scan
+        
+    Listar redes disponibles:
+        
+        station <dispositivo> get-networks
+     
+    Conectarse a una red:
+    
+        station <dispositivo> connect <SSID>
 
-    *Seleccionar la red, e ingresar contraseña.*
+    Salir de iwctl:
+    
+        exit
 
 8. Activar la sincronización del reloj del sistema con Internet: 
 


### PR DESCRIPTION
En junio se se decidió cambiar `wifi-menu` por `iwctl` para la conexión por WiFi en el instalador:

- [Se elimina netctl](https://gitlab.archlinux.org/archlinux/archiso/-/commit/32eef254b670b7855bf9480ef22dab58c5f2114f)
- [Se añade iwctl](https://gitlab.archlinux.org/archlinux/archiso/-/commit/3ed5dd510d24cb4e4b29bb2d3e3574c6d985051b)
- La [guía de instalación oficial ahora menciona iwctl](https://wiki.archlinux.org/index.php/Installation_guide#Connect_to_the_internet) para realizar la conexión inalambrica.